### PR TITLE
Only duplicate headers if they already exist

### DIFF
--- a/applications/proxyserver.js
+++ b/applications/proxyserver.js
@@ -52,11 +52,12 @@ function reverseProxy(remapper) {
 	var url = urllib.parse(options.url);
 	var hostname = url.hostname;
 	var resource = url.path;
+	var protocol = url.protocol;
 	if (!options.hasOwnProperty('headers')) {
 	  options.headers = {};
 	}
 	if (remapper.hasOwnProperty(hostname)) {
-	  options.url = urllib.resolve(remapper[hostname], resource);
+	  options.url = urllib.resolve(protocol + "//" + remapper[hostname], resource);
 	  options.headers['Host'] = hostname;
 	}
 	next(null, options);

--- a/applications/proxyserver.js
+++ b/applications/proxyserver.js
@@ -64,7 +64,7 @@ function reverseProxy(remapper) {
   };
 }
 
-var remapper = {};
+var remapper = {"distributed.deflect.ca": "deflect.ca"};
 
 function handleRequests(req, res) {
   var url = qs.parse(urllib.parse(req.url).query).url;
@@ -88,6 +88,7 @@ function handleRequests(req, res) {
 	bundleMaker.on('originalRequest', bundler.followRedirects(
 		config.followFirstRedirect, config.followAllRedirects, config.redirectLimit));
 
+  bundleMaker.on('originalRequest', reverseProxy(remapper));
   bundleMaker.on('resourceRequest', reverseProxy(remapper));
 
 	bundleMaker.bundle(function (err, bundle) {

--- a/applications/proxyserver.js
+++ b/applications/proxyserver.js
@@ -40,7 +40,9 @@ _.extend(config, JSON.parse(fs.readFileSync(configFile)));
 function extractHeaders(req, headers) {
 	var newHeaders = {};
 	for (var i = 0, len = headers.length; i < len; ++i) {
-		newHeaders[headers[i]] = req.headers[headers[i]];
+		if (req.headers.hasOwnProperty(headers[i])) {
+			newHeaders[headers[i]] = req.headers[headers[i]];
+		}
 	}
 	return newHeaders;
 }

--- a/applications/proxyserver.js
+++ b/applications/proxyserver.js
@@ -64,7 +64,8 @@ function reverseProxy(remapper) {
   };
 }
 
-var remapper = {"distributed.deflect.ca": "deflect.ca"};
+var remapper = {"distributed.deflect.ca": "deflect.ca",
+               "nosmo.me": "fulltimeinter.net"};
 
 function handleRequests(req, res) {
   var url = qs.parse(urllib.parse(req.url).query).url;

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -5,7 +5,7 @@
  * replace different resources as well as a couple of functions, namely
  * mimetype and dataURI to help in writing custom handlers.
  */
- 
+
 var _ = require('lodash');
 var async = require('async');
 var request = require('request');
@@ -22,8 +22,8 @@ var log = require('./logger');
 
 function Bundler(url) {
   this.url = url;
-  this.resourceHandlers = new Array(); 
-  this.originalRequestHooks = new Array(); 
+  this.resourceHandlers = new Array();
+  this.originalRequestHooks = new Array();
   this.resourceRequestHooks = new Array();
   this.resourceReceivedHooks = new Array();
   this.diffHooks = new Array();
@@ -56,7 +56,11 @@ Bundler.prototype.on = function (hookname, handler) {
 
 Bundler.prototype.bundle = function (callback) {
   this.callback = callback;
-  var initOptions = { url: this.url };
+  var initOptions = {
+      url: this.url,
+      strictSSL: false,
+      rejectUnauthorized: false
+  };
   var thisBundler = this;
   async.reduce(this.originalRequestHooks, initOptions, function (memo, hook, next) {
     log.debug('in Bundler.send/async.reduce, memo =', memo);
@@ -74,7 +78,7 @@ Bundler.prototype.bundle = function (callback) {
 function makeBundle(bundler, options) {
   request(options, function (err, res, body) {
     if (err) {
-      log.error('Error making request to %s; Error: %s', bundler.url, err.message);
+      log.error('Error making request to %s; Error: %s %s', bundler.url, err.stack, err.message);
       bundler.callback(err, null);
     } else {
       invokeHandlers(bundler, body, wrappedRequest(bundler, res, body));


### PR DESCRIPTION
Doesn't really need a feature branch but just want to be sure I'm doing this right. Was causing the following on node v0.12.0 for some reason. 

```
Proxy server listening on 127.0.0.1:9008
New headers for referer set to undefined
New headers for cookie set to undefined
debug: in Bundler.send/async.reduce, memo = url=http://nosmo.me
debug: in Bundler.send/async.reduce, memo = url=http://nosmo.me, referer=undefined, cookie=undefined
debug: in Bundler.send/async.reduce, memo = url=http://nosmo.me, referer=undefined, cookie=undefined, Origin=Bundler
_http_outgoing.js:333
    throw new Error('"name" and "value" are required for setHeader().');
          ^
Error: "name" and "value" are required for setHeader().
    at ClientRequest.OutgoingMessage.setHeader (_http_outgoing.js:333:11)
    at new ClientRequest (_http_client.js:101:14)
    at Object.exports.request (http.js:49:10)
    at Request.start (/root/bundler/node_modules/request/request.js:904:30)
    at Request.end (/root/bundler/node_modules/request/request.js:1635:10)
    at end (/root/bundler/node_modules/request/request.js:676:14)
    at Immediate._onImmediate (/root/bundler/node_modules/request/request.js:690:7)
    at processImmediate [as _immediateCallback] (timers.js:358:17)
```