### PR TITLE
Allow config location specification

### DIFF
--- a/applications/psconfig.json
+++ b/applications/psconfig.json
@@ -3,6 +3,8 @@
 	"drop_user": "nobody",
 	"drop_group": "nogroup",
 	"proxyAddress": "localhost:9008",
+	"listenAddress": "127.0.0.1",
+	"listenPort": 9008,
 	"followFirstRedirect": true,
 	"followAllRedirects": false,
 	"redirectLimit": 10,


### PR DESCRIPTION
Use `minimist` to allow specification of the location of the psconfig.json file. 
Move the location of port and listen address to the configuration file. 